### PR TITLE
chore: bump simplexmq from 6.2.0 to 6.4.5

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,11 +1,16 @@
 id: simplex
 title: "SimpleX Server"
-version: 6.2.0.7
+version: 6.4.5.1
 release-notes: |
-  - Updated to the latest upstream code with notable changes:
-    * journal storage for messages (BETA).
-    * prevent race condition when deleting queue and to avoid "orphan" messages.
-    * Full change log available [here](https://github.com/simplex-chat/simplexmq/blob/master/CHANGELOG.md#620)
+  - Updated simplexmq from 6.2.0 to 6.4.5 with notable changes:
+    * PostgreSQL support for queue records (for high-traffic servers)
+    * Prometheus metrics for SMP and XFTP servers
+    * Short connection links support
+    * Store log enabled by default
+    * Content moderation blocking records
+    * Multiple memory leak fixes
+    * Stability and reliability improvements
+    * Full change log available [here](https://github.com/simplex-chat/simplexmq/blob/master/CHANGELOG.md)
 license: MIT
 wrapper-repo: "https://github.com/Start9Labs/simplex-startos"
 upstream-repo: "https://github.com/simplex-chat/simplexmq/"


### PR DESCRIPTION
## Summary

- Bumps the `simplexmq` submodule from v6.2.0 to v6.4.5
- Updates `manifest.yaml` version from `6.2.0.7` to `6.4.5.1`
- Updates release notes with key upstream changes

## Upstream Changes (6.2.0 → 6.4.5)

This is a significant minor version update spanning multiple releases with major new features and improvements:

### New Features
- **PostgreSQL support** for queue records — designed for high-traffic servers that need database-backed storage
- **Prometheus metrics** for both SMP and XFTP servers — enables monitoring and observability
- **Short connection links** support — simplified link sharing
- **Store log enabled by default** — improved data durability out of the box
- **Content moderation** blocking records

### Improvements
- Multiple memory leak fixes across several releases
- Stability and reliability improvements
- Various bug fixes

### Proposed Features to Expose

The following upstream features could be exposed to StartOS users in future updates:

1. **PostgreSQL backend** — Could be offered as an optional configuration for users running high-traffic servers. Would require adding a PostgreSQL dependency or bundling it in the container.
2. **Prometheus metrics endpoint** — Could be exposed as a new interface for users who want to monitor their server with Grafana or similar tools.
3. **Short links configuration** — May require new config options to enable/customize.

These features are **not implemented** in this PR — this PR only bumps the version. The features above are proposed for discussion and follow-up work.

## Full Changelog

https://github.com/simplex-chat/simplexmq/blob/master/CHANGELOG.md