### PR TITLE
Bump SimpleX to 6.5.0, add aarch64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
-ARCHES := x86
+ARCHES := x86 arm
 # overrides to s9pk.mk must precede the include statement
 include s9pk.mk

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This package runs **2 containers**:
 | smp | `simplexchat/smp-server` | SimpleX Messaging Protocol server |
 | xftp | `simplexchat/xftp-server` | SimpleX File Transfer Protocol server |
 
-- **Architectures:** x86_64 only
+- **Architectures:** x86_64, aarch64
 - **Entrypoint:** Default upstream entrypoints for both containers
 
 ## Volume and Data Layout
@@ -133,12 +133,11 @@ When `enableTorProxy` is off (default), the package has no runtime dependencies.
 
 ## Limitations and Differences
 
-1. **x86_64 only** — aarch64 is not yet supported
-2. **No web UI** — server administration is config-file only
-3. **Fixed storage quota** — XFTP is limited to 10 GB (requires direct INI file edit to change)
-4. **No stats dashboard** — Prometheus metrics interval is not configured by default
-5. **TLS is not served by smp-server** — StartOS terminates TLS for the web info page, so `WEB.https`/`cert`/`key` are stripped from `smp-server.ini` on every merge; Let's Encrypt / direct HTTPS configuration on the smp-server side is disabled by design
-6. **Tor SOCKS proxy is opt-in only** — the `[PROXY] socks_proxy` setting is toggled solely by the `tor-settings` action; hand-edits to that field will be overwritten on the next init run
+1. **No web UI** — server administration is config-file only
+2. **Fixed storage quota** — XFTP is limited to 10 GB (requires direct INI file edit to change)
+3. **No stats dashboard** — Prometheus metrics interval is not configured by default
+4. **TLS is not served by smp-server** — StartOS terminates TLS for the web info page, so `WEB.https`/`cert`/`key` are stripped from `smp-server.ini` on every merge; Let's Encrypt / direct HTTPS configuration on the smp-server side is disabled by design
+5. **Tor SOCKS proxy is opt-in only** — the `[PROXY] socks_proxy` setting is toggled solely by the `tor-settings` action; hand-edits to that field will be overwritten on the next init run
 
 ## What Is Unchanged from Upstream
 
@@ -159,7 +158,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for build instructions and development wo
 ```yaml
 package_id: simplex
 image: simplexchat/smp-server, simplexchat/xftp-server
-architectures: [x86_64]
+architectures: [x86_64, aarch64]
 volumes:
   smp-configs: /etc/opt/simplex
   smp-state: /var/opt/simplex

--- a/package-lock.json
+++ b/package-lock.json
@@ -361,7 +361,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/startos/fileModels/ini-lib.ts
+++ b/startos/fileModels/ini-lib.ts
@@ -68,7 +68,7 @@ function isSection(
 }
 
 /**
- * Parse an INI string that uses `: ` as the key/value separator
+ * Parse an INI string that uses `=` as the key/value separator
  */
 export function parse(content: string, options: ParseOptions = {}): IniData {
   const result: IniData = {}
@@ -92,11 +92,11 @@ export function parse(content: string, options: ParseOptions = {}): IniData {
       continue
     }
 
-    // Parse key: value pairs
-    const separatorIndex = trimmed.indexOf(': ')
+    // Parse key = value pairs (first `=` is the separator)
+    const separatorIndex = trimmed.indexOf('=')
     if (separatorIndex !== -1) {
       const key = trimmed.slice(0, separatorIndex).trim()
-      const rawValue = trimmed.slice(separatorIndex + 2)
+      const rawValue = trimmed.slice(separatorIndex + 1)
       const value = parseValue(rawValue, options)
 
       if (currentSection) {
@@ -111,7 +111,7 @@ export function parse(content: string, options: ParseOptions = {}): IniData {
 }
 
 /**
- * Stringify an object to INI format using `: ` as the key/value separator
+ * Stringify an object to INI format using `=` as the key/value separator
  * Note: null and undefined values are omitted (INI has no native null concept)
  */
 export function stringify(
@@ -124,7 +124,7 @@ export function stringify(
   for (const [key, value] of Object.entries(data)) {
     if (value == null) continue // filters both null and undefined
     if (!isSection(value)) {
-      lines.push(`${key}: ${stringifyValue(value, options)}`)
+      lines.push(`${key} = ${stringifyValue(value, options)}`)
     }
   }
 
@@ -135,7 +135,7 @@ export function stringify(
       const sectionLines: string[] = []
       for (const [subKey, subValue] of Object.entries(value)) {
         if (subValue == null) continue
-        sectionLines.push(`${subKey}: ${stringifyValue(subValue, options)}`)
+        sectionLines.push(`${subKey} = ${stringifyValue(subValue, options)}`)
       }
       // Only add section if it has values
       if (sectionLines.length > 0) {

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -25,17 +25,15 @@ export const manifest = setupManifest({
   images: {
     smp: {
       source: {
-        dockerTag: 'simplexchat/smp-server:v6.4.5',
+        dockerTag: 'simplexchat/smp-server:v6.5.0',
       },
-      // @TODO aarch64 coming after 6.4.5
-      arch: ['x86_64'],
+      arch: ['x86_64', 'aarch64'],
     },
     xftp: {
       source: {
-        dockerTag: 'simplexchat/xftp-server:v6.4.5',
+        dockerTag: 'simplexchat/xftp-server:v6.5.0',
       },
-      // @TODO aarch64 coming after 6.4.5
-      arch: ['x86_64'],
+      arch: ['x86_64', 'aarch64'],
     },
   },
   dependencies: {

--- a/startos/versions/index.ts
+++ b/startos/versions/index.ts
@@ -1,7 +1,8 @@
 import { VersionGraph } from '@start9labs/start-sdk'
 import { v_6_4_5_8 } from './v6.4.5_8'
+import { v_6_5_0_0 } from './v6.5.0_0'
 
 export const versionGraph = VersionGraph.of({
-  current: v_6_4_5_8,
-  other: [],
+  current: v_6_5_0_0,
+  other: [v_6_4_5_8],
 })

--- a/startos/versions/v6.5.0_0.ts
+++ b/startos/versions/v6.5.0_0.ts
@@ -1,0 +1,95 @@
+import { IMPOSSIBLE, VersionInfo } from '@start9labs/start-sdk'
+import { readFile, writeFile } from 'fs/promises'
+
+// SimpleX v6.5.0 changed the INI key/value separator from `: ` to `=`.
+const INI_PATHS = [
+  '/media/startos/volumes/smp-configs/smp-server.ini',
+  '/media/startos/volumes/xftp-configs/file-server.ini',
+]
+
+export const v_6_5_0_0 = VersionInfo.of({
+  version: '6.5.0:0',
+  releaseNotes: {
+    en_US: `**Bumps**
+
+- SimpleX → 6.5.0
+
+**Features**
+
+- aarch64 builds are now supported in addition to x86_64.
+
+**Internal**
+
+- Migrated config files to the new \`=\` separator format introduced upstream in 6.5.0.`,
+    es_ES: `**Actualizaciones**
+
+- SimpleX → 6.5.0
+
+**Funcionalidades**
+
+- Ahora se admiten compilaciones aarch64 además de x86_64.
+
+**Interno**
+
+- Se migraron los archivos de configuración al nuevo separador \`=\` introducido en 6.5.0.`,
+    de_DE: `**Aktualisierungen**
+
+- SimpleX → 6.5.0
+
+**Funktionen**
+
+- aarch64-Builds werden jetzt zusätzlich zu x86_64 unterstützt.
+
+**Intern**
+
+- Konfigurationsdateien auf das neue \`=\`-Trennzeichen aus 6.5.0 umgestellt.`,
+    pl_PL: `**Aktualizacje**
+
+- SimpleX → 6.5.0
+
+**Funkcje**
+
+- Obsługa kompilacji aarch64 oprócz x86_64.
+
+**Wewnętrzne**
+
+- Pliki konfiguracyjne przeniesione na nowy separator \`=\` z 6.5.0.`,
+    fr_FR: `**Mises à jour**
+
+- SimpleX → 6.5.0
+
+**Fonctionnalités**
+
+- Les builds aarch64 sont désormais pris en charge en plus de x86_64.
+
+**Interne**
+
+- Fichiers de configuration migrés vers le nouveau séparateur \`=\` introduit en 6.5.0.`,
+  },
+  migrations: {
+    up: async () => {
+      await Promise.all(INI_PATHS.map(rewriteIniSeparator))
+    },
+    down: IMPOSSIBLE,
+  },
+})
+
+async function rewriteIniSeparator(path: string) {
+  const text = await readFile(path, 'utf-8').catch(() => null)
+  if (text === null) return
+  const converted = text
+    .split(/\r?\n/)
+    .map((line) => {
+      const trimmed = line.trim()
+      if (!trimmed) return line
+      if (trimmed.startsWith('#') || trimmed.startsWith(';')) return line
+      if (/^\[[^\]]+\]$/.test(trimmed)) return line
+      const idx = line.indexOf(': ')
+      if (idx === -1) return line
+      return `${line.slice(0, idx)} = ${line.slice(idx + 2)}`
+    })
+    .join('\n')
+  if (converted !== text) {
+    await writeFile(path, converted)
+  }
+}


### PR DESCRIPTION
## Summary

- **Upstream:** SimpleX → **6.5.0** (`simplexchat/smp-server`, `simplexchat/xftp-server`). Latest stable upstream release; previous shipping version was 6.4.5.
- **aarch64 support:** Upstream now publishes multi-arch images (amd64 + arm64). Dropped the `arch: ['x86_64']` restriction on both images and added `arm` to the Makefile's `ARCHES`. Both `.s9pk` artifacts build clean locally.
- **INI separator migration:** SimpleX 6.5.0 ([simplexmq#1767](https://github.com/simplex-chat/simplexmq/pull/1767)) changed the INI key/value separator from `: ` to `=`. The smp-server / xftp-server binaries will refuse to parse the old format, and the upstream docker entrypoints only run `*-server init` when the INI file is absent — so existing installations need their files rewritten.
  - `startos/fileModels/ini-lib.ts`: parser and stringifier now use `=`.
  - New version `6.5.0:0` with an `up` migration that rewrites `smp-server.ini` and `file-server.ini` line-by-line (skipping comments and section headers), preserving all unmanaged keys. `6.4.5:8` moved to `other` so the migration path runs.

## Test plan

- [x] `make` builds clean for both x86_64 and aarch64.
- [ ] Sideload `simplex_x86_64.s9pk` on a 6.4.5:8 install and verify the migration converts the INI files and both daemons come back up healthy.
- [ ] Fresh install on x86_64 — `smp-server init` writes the new `=` format, our `merge()` round-trips correctly, AUTH password persists.
- [ ] Fresh install on aarch64.