### PR TITLE
chore: bump start-sdk to 1.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "hello-world-startos",
       "dependencies": {
-        "@start9labs/start-sdk": "1.5.1",
+        "@start9labs/start-sdk": "1.5.2",
         "tldts": "^7.0.19"
       },
       "devDependencies": {
@@ -62,9 +62,9 @@
       "license": "MIT"
     },
     "node_modules/@start9labs/start-sdk": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.1.tgz",
-      "integrity": "sha512-iztLiOCtHuTfUCd2JOWio4OvBk5qFGa0NI+G+ZB/dQ1sWtunYEnzqMcF6N/Ss4L6+7bBOMAMU4VuhyxeZoHyIw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.2.tgz",
+      "integrity": "sha512-3L4OKuH9kUtuH6G20BSPk85yN/jS3+0WNkP19ahwO9Nc7L6STel4hujvKii3osf0p0tU2q5Mk2Y8b9f2dVR1ng==",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",
@@ -361,6 +361,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@start9labs/start-sdk": "1.5.1",
+    "@start9labs/start-sdk": "1.5.2",
     "tldts": "^7.0.19"
   },
   "devDependencies": {

--- a/startos/versions/index.ts
+++ b/startos/versions/index.ts
@@ -1,7 +1,7 @@
 import { VersionGraph } from '@start9labs/start-sdk'
-import { v_6_5_0_2 } from './v6.5.0_2'
+import { v_6_5_0_3 } from './v6.5.0_3'
 
 export const versionGraph = VersionGraph.of({
-  current: v_6_5_0_2,
+  current: v_6_5_0_3,
   other: [],
 })

--- a/startos/versions/v6.5.0_3.ts
+++ b/startos/versions/v6.5.0_3.ts
@@ -7,18 +7,14 @@ import { smpServerIni } from '../fileModels/smpServer.ini'
 
 // NOTE, adding passwords to xftp server addresses. Previous addresses are less secure and expected to break.
 
-export const v_6_5_0_2 = VersionInfo.of({
-  version: '6.5.0:2',
+export const v_6_5_0_3 = VersionInfo.of({
+  version: '6.5.0:3',
   releaseNotes: {
-    en_US: 'Restore 0.3.5.1 → 0.4.x volume-layout migration dropped in 6.5.0:1.',
-    es_ES:
-      'Restaura la migración de diseño de volúmenes 0.3.5.1 → 0.4.x eliminada en 6.5.0:1.',
-    de_DE:
-      'Stellt die in 6.5.0:1 entfernte Volumen-Layout-Migration 0.3.5.1 → 0.4.x wieder her.',
-    pl_PL:
-      'Przywraca migrację układu woluminów 0.3.5.1 → 0.4.x usuniętą w 6.5.0:1.',
-    fr_FR:
-      'Restaure la migration de disposition des volumes 0.3.5.1 → 0.4.x supprimée en 6.5.0:1.',
+    en_US: 'Updated to start-sdk 1.5.2.',
+    es_ES: 'Actualizado a start-sdk 1.5.2.',
+    de_DE: 'Aktualisierung auf start-sdk 1.5.2.',
+    pl_PL: 'Zaktualizowano do start-sdk 1.5.2.',
+    fr_FR: 'Mise à jour vers start-sdk 1.5.2.',
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
Bumps `@start9labs/start-sdk` 1.5.1 → 1.5.2 and increments revision `6.5.0:2` → `6.5.0:3`.

Replaces helix PR #14 (closed; conflicted with master).