### PR TITLE
feat: add aarch64 support and fix manifest license to AGPL-3.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
-ARCHES := x86
+ARCHES := x86 arm
 # overrides to s9pk.mk must precede the include statement
 include s9pk.mk

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This package runs **2 containers**:
 | smp | `simplexchat/smp-server` | SimpleX Messaging Protocol server |
 | xftp | `simplexchat/xftp-server` | SimpleX File Transfer Protocol server |
 
-- **Architectures:** x86_64 only
+- **Architectures:** x86_64 and aarch64
 - **Entrypoint:** Default upstream entrypoints for both containers
 
 ## Volume and Data Layout
@@ -74,7 +74,7 @@ On update/restore, existing configuration files are merged with defaults (preser
 
 | StartOS-Managed (enforced) | Upstream-Managed (pass-through) |
 |------------------------------------|------------------|
-| `TRANSPORT.host: <hostnames>`, `TRANSPORT.port: 5223,443` (smp) / `5225` (xftp) | Control ports, stats/prometheus, log levels |
+| `TRANSPORT.host: <hostnames>`, `TRANSPORT.port: 5223,443` (smp) / `5225` (xftp); smp also pins `control_port: 5224`, `log_tls_errors: off`, `websockets: off` | Stats / Prometheus interval |
 | `STORE_LOG.enable: on`, `expire_messages_days: 365`, `expire_messages_on_start: off`, `expire_ntfs_hours: 168` (smp) | Any other key not listed here |
 | `FILES.path`, `FILES.storage_quota: 10gb` (xftp) | |
 | `AUTH.create_password` (auto-generated 21-char) | |
@@ -133,12 +133,11 @@ When `enableTorProxy` is off (default), the package has no runtime dependencies.
 
 ## Limitations and Differences
 
-1. **x86_64 only** — aarch64 is not yet supported
-2. **No web UI** — server administration is config-file only
-3. **Fixed storage quota** — XFTP is limited to 10 GB (requires direct INI file edit to change)
-4. **No stats dashboard** — Prometheus metrics interval is not configured by default
-5. **TLS is not served by smp-server** — StartOS terminates TLS for the web info page, so `WEB.https`/`cert`/`key` are stripped from `smp-server.ini` on every merge; Let's Encrypt / direct HTTPS configuration on the smp-server side is disabled by design
-6. **Tor SOCKS proxy is opt-in only** — the `[PROXY] socks_proxy` setting is toggled solely by the `tor-settings` action; hand-edits to that field will be overwritten on the next init run
+1. **No web UI** — server administration is config-file only
+2. **Fixed storage quota** — XFTP is limited to 10 GB (requires direct INI file edit to change)
+3. **No stats dashboard** — Prometheus metrics interval is not configured by default
+4. **TLS is not served by smp-server** — StartOS terminates TLS for the web info page, so `WEB.https`/`cert`/`key` are stripped from `smp-server.ini` on every merge; Let's Encrypt / direct HTTPS configuration on the smp-server side is disabled by design
+5. **Tor SOCKS proxy is opt-in only** — the `[PROXY] socks_proxy` setting is toggled solely by the `tor-settings` action; hand-edits to that field will be overwritten on the next init run
 
 ## What Is Unchanged from Upstream
 
@@ -159,7 +158,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for build instructions and development wo
 ```yaml
 package_id: simplex
 image: simplexchat/smp-server, simplexchat/xftp-server
-architectures: [x86_64]
+architectures: [x86_64, aarch64]
 volumes:
   smp-configs: /etc/opt/simplex
   smp-state: /var/opt/simplex

--- a/instructions.md
+++ b/instructions.md
@@ -36,4 +36,4 @@ This setting is opt-in: hand-edits to the `[PROXY] socks_proxy` field in the INI
 
 ### Advanced configuration
 
-Most upstream `smp-server.ini`, `file-server.ini`, and `xftp-server.ini` fields are passed through unchanged. The package only enforces a small set of keys (transport address, store-log retention, file path, storage quota, web TLS, and the proxy field above); anything else you set by editing the INI files directly in the config volumes will be preserved.
+Most upstream `smp-server.ini` and `file-server.ini` fields are passed through unchanged. The package only enforces a small set of keys (transport settings, store-log retention, file path, storage quota, web TLS, and the proxy field above); anything else you set by editing the INI files directly in the config volumes will be preserved.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hello-world-startos",
+  "name": "simplex-startos",
   "scripts": {
     "build": "rm -rf ./javascript && ncc build startos/index.ts -o ./javascript",
     "prettier": "prettier --write startos",

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -4,7 +4,7 @@ import i18n from './i18n'
 export const manifest = setupManifest({
   id: 'simplex',
   title: 'SimpleX Server',
-  license: 'MIT',
+  license: 'AGPL-3.0',
   packageRepo: 'https://github.com/Start9Labs/simplex-startos',
   upstreamRepo: 'https://github.com/simplex-chat/simplexmq/',
   marketingUrl: 'https://simplex.chat/',
@@ -27,13 +27,13 @@ export const manifest = setupManifest({
       source: {
         dockerTag: 'simplexchat/smp-server:v6.5.0',
       },
-      arch: ['x86_64'],
+      arch: ['x86_64', 'aarch64'],
     },
     xftp: {
       source: {
         dockerTag: 'simplexchat/xftp-server:v6.5.0',
       },
-      arch: ['x86_64'],
+      arch: ['x86_64', 'aarch64'],
     },
   },
   dependencies: {

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -8,18 +8,13 @@ import { smpServerIni } from '../fileModels/smpServer.ini'
 // NOTE, adding passwords to xftp server addresses. Previous addresses are less secure and expected to break.
 
 export const current = VersionInfo.of({
-  version: '6.5.0:3',
+  version: '6.5.0:4',
   releaseNotes: {
-    en_US:
-      'Fix SMP server failing to start on fresh installs ("no key websockets in section TRANSPORT").',
-    es_ES:
-      'Corrige el fallo de inicio del servidor SMP en instalaciones nuevas ("no key websockets in section TRANSPORT").',
-    de_DE:
-      'Behebt den Startfehler des SMP-Servers bei Neuinstallationen ("no key websockets in section TRANSPORT").',
-    pl_PL:
-      'Naprawia błąd uruchamiania serwera SMP przy nowych instalacjach ("no key websockets in section TRANSPORT").',
-    fr_FR:
-      'Corrige l\'échec de démarrage du serveur SMP lors des nouvelles installations ("no key websockets in section TRANSPORT").',
+    en_US: 'Add aarch64 (ARM64) architecture support.',
+    es_ES: 'Añade compatibilidad con la arquitectura aarch64 (ARM64).',
+    de_DE: 'Unterstützung für die aarch64-Architektur (ARM64) hinzugefügt.',
+    pl_PL: 'Dodano obsługę architektury aarch64 (ARM64).',
+    fr_FR: "Ajout de la prise en charge de l'architecture aarch64 (ARM64).",
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

Adds aarch64 support, corrects the package license, and audits the docs against the codebase. Ships as `6.5.0:4`.

### License (`AGPL-3.0`)
The repo's `LICENSE` file is GNU AGPL v3 and upstream `simplex-chat/simplexmq` is `AGPL-3.0`, but the manifest still declared `MIT`. A prior commit (`678e97d`) corrected the `LICENSE` file but missed the manifest field — this finishes that. `AGPL-3.0` matches the form used by the other AGPL packages in the registry.

### aarch64 support
Both pinned images already publish `linux/arm64` at the current tag (`simplexchat/smp-server:v6.5.0`, `simplexchat/xftp-server:v6.5.0`), so no upstream bump was needed.
- `arch: ['x86_64', 'aarch64']` on both `smp` and `xftp` images.
- `Makefile` builds the arm artifact (`ARCHES := x86 arm`); riscv omitted — no riscv64 image upstream.
- Version bumped `6.5.0:3` → `6.5.0:4` (required for `tagAndRelease` to ship) with a translated release note. The legacy-volume migration is unaffected (self-gated on a `stats.yaml` no current install carries).

### README / instructions audit
- **Config Management table** — the smp `TRANSPORT` schema pins `control_port: 5224`, `log_tls_errors: off`, and `websockets: off` (all `z.literal`s), but they were listed as upstream *pass-through*. Moved into the enforced column.
- **instructions.md** — removed the phantom `xftp-server.ini` (only `smp-server.ini` and `file-server.ini` are managed); broadened "transport address" → "transport settings".
- **Arch references** — runtime bullet, `Limitations` list (dropped the false "x86_64 only" item), and Quick-Reference YAML.
- **package.json** — `name` was the boilerplate `hello-world-startos` → `simplex-startos`.

Volume layout, ports, masked URL format, health checks, backup set, the `tor-settings` action, the tor version pin, and the first-run init flow were all cross-checked and already accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)