### PR TITLE
chore: bump SimpleX to 7.0.0; 6.5.2:5 → 7.0.0:0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1754,7 +1754,7 @@
       "license": "MIT"
     },
     "node_modules/tor-startos": {
-      "resolved": "git+ssh://git@github.com/Start9Labs/tor-startos.git#e3e2b53a84cb92855ac7b35764df288fab1fa333",
+      "resolved": "git+ssh://git@github.com/Start9Labs/tor-startos.git#aa867cfea0f20095feb56e96cad3510393d912de",
       "dependencies": {
         "@noble/curves": "*",
         "@start9labs/start-sdk": "2.0.7",

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -25,13 +25,13 @@ export const manifest = setupManifest({
   images: {
     smp: {
       source: {
-        dockerTag: 'simplexchat/smp-server:v6.5.2',
+        dockerTag: 'simplexchat/smp-server:v7.0.0',
       },
       arch: ['x86_64', 'aarch64'],
     },
     xftp: {
       source: {
-        dockerTag: 'simplexchat/xftp-server:v6.5.2',
+        dockerTag: 'simplexchat/xftp-server:v7.0.0',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,23 +1,48 @@
 import { VersionInfo } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '6.5.2:5',
+  version: '7.0.0:0',
   releaseNotes: {
-    en_US: `Resolves the addresses of connected services more reliably.
+    en_US: `Updated SimpleX to 7.0.0.
 
-SimpleX looked up where to reach its dependencies through a field that only applies to one of the two ways a service can publish a port. It now reads the address itself, so a dependency changing how it serves TLS can no longer leave SimpleX unable to find it. Nothing changes in normal operation.`,
-    es_ES: `Resuelve de forma más fiable las direcciones de los servicios conectados.
+- Fixes two memory leaks in the SMP server that grew as clients subscribed and unsubscribed.
+- The SMP proxy reconnects reliably to a relay after that relay restarts.
+- Hardening across cryptography and message parsing, including a limit on decompressed message size.
+- Accepts IPv6 server addresses written in bracketed form.
 
-SimpleX localizaba sus dependencias mediante un campo que solo se aplica a una de las dos formas en que un servicio puede publicar un puerto. Ahora lee la dirección en sí, de modo que si una dependencia cambia su forma de servir TLS, SimpleX seguirá encontrándola. En funcionamiento normal no cambia nada.`,
-    de_DE: `Ermittelt die Adressen verbundener Dienste zuverlässiger.
+Full upstream release notes: https://github.com/simplex-chat/simplexmq/releases/tag/v7.0.0`,
+    es_ES: `Actualiza SimpleX a la versión 7.0.0.
 
-SimpleX suchte seine Abhängigkeiten über ein Feld, das nur für eine der beiden Arten gilt, auf die ein Dienst einen Port veröffentlichen kann. Jetzt wird die Adresse selbst gelesen, sodass eine Abhängigkeit, die ihre TLS-Bereitstellung ändert, für SimpleX auffindbar bleibt. Im normalen Betrieb ändert sich nichts.`,
-    pl_PL: `Pewniej ustala adresy połączonych usług.
+- Corrige dos fugas de memoria en el servidor SMP que crecían a medida que los clientes se suscribían y cancelaban su suscripción.
+- El proxy SMP se reconecta de forma fiable a un repetidor después de que este se reinicie.
+- Refuerzo de la criptografía y del análisis de mensajes, incluido un límite en el tamaño de los mensajes descomprimidos.
+- Acepta direcciones de servidor IPv6 escritas entre corchetes.
 
-SimpleX wyszukiwał swoje zależności przez pole, które dotyczy tylko jednego z dwóch sposobów publikowania portu przez usługę. Teraz odczytuje sam adres, więc zależność zmieniająca sposób udostępniania TLS nadal pozostanie odnajdywalna dla SimpleX. W normalnej pracy nic się nie zmienia.`,
-    fr_FR: `Détermine plus fiablement les adresses des services connectés.
+Notas completas de la versión original: https://github.com/simplex-chat/simplexmq/releases/tag/v7.0.0`,
+    de_DE: `Aktualisiert SimpleX auf 7.0.0.
 
-SimpleX localisait ses dépendances via un champ qui ne s'applique qu'à l'un des deux modes de publication d'un port par un service. Il lit désormais l'adresse elle-même : une dépendance qui change sa façon de servir TLS reste donc trouvable par SimpleX. Rien ne change en fonctionnement normal.`,
+- Behebt zwei Speicherlecks im SMP-Server, die mit dem An- und Abmelden von Clients anwuchsen.
+- Der SMP-Proxy verbindet sich nach einem Neustart des Relays zuverlässig wieder mit diesem.
+- Härtung von Kryptografie und Nachrichtenverarbeitung, einschließlich einer Begrenzung der entpackten Nachrichtengröße.
+- Akzeptiert IPv6-Serveradressen in Klammerschreibweise.
+
+Vollständige Versionshinweise des Upstream-Projekts: https://github.com/simplex-chat/simplexmq/releases/tag/v7.0.0`,
+    pl_PL: `Aktualizuje SimpleX do wersji 7.0.0.
+
+- Naprawia dwa wycieki pamięci w serwerze SMP, które narastały wraz z subskrybowaniem i anulowaniem subskrypcji przez klientów.
+- Proxy SMP niezawodnie łączy się ponownie z przekaźnikiem po jego ponownym uruchomieniu.
+- Wzmocnienia w kryptografii i przetwarzaniu wiadomości, w tym limit rozmiaru zdekompresowanych wiadomości.
+- Obsługuje adresy serwerów IPv6 zapisane w nawiasach kwadratowych.
+
+Pełne informacje o wydaniu od twórców: https://github.com/simplex-chat/simplexmq/releases/tag/v7.0.0`,
+    fr_FR: `Met à jour SimpleX vers la version 7.0.0.
+
+- Corrige deux fuites de mémoire du serveur SMP qui augmentaient au fil des abonnements et désabonnements des clients.
+- Le proxy SMP se reconnecte de manière fiable à un relais après le redémarrage de celui-ci.
+- Renforcement de la cryptographie et de l'analyse des messages, dont une limite sur la taille des messages décompressés.
+- Accepte les adresses de serveur IPv6 écrites entre crochets.
+
+Notes de version complètes du projet amont : https://github.com/simplex-chat/simplexmq/releases/tag/v7.0.0`,
   },
   migrations: {},
 })


### PR DESCRIPTION
## Summary

Bumps the two upstream images to **simplexmq v7.0.0** (from v6.5.2) and refreshes the `tor-startos` git dependency. StartOS version `6.5.2:5` → `7.0.0:0`.

Both binaries ship from a single upstream release and are bumped in lockstep, per `UPDATING.md`:

| image | from | to |
| --- | --- | --- |
| `simplexchat/smp-server` | `v6.5.2` | `v7.0.0` |
| `simplexchat/xftp-server` | `v6.5.2` | `v7.0.0` |

## Upstream verification

- Newest stable tag via the `UPDATING.md` query (which filters out `v7.0.0-beta.*`): **`v7.0.0`**.
- GitHub flags this release `prerelease: true` — this is the documented upstream quirk `UPDATING.md` warns about (`gh release view` still returns v6.5.0). The tag is a plain `vX.Y.Z`, and Docker `latest`/`v7`/`v7.0` all point at it.
- **Both** images confirmed published on Docker Hub for `amd64` + `arm64` (pushed 2026-07-29):
  - `smp-server:v7.0.0` → `sha256:caf2d6f5…`
  - `xftp-server:v7.0.0` → `sha256:35aaf5a5…`
- Image `Entrypoint` is `/usr/local/bin/entrypoint` on both images in both versions — unchanged, so `sdk.useEntrypoint()` still applies.

## Major-version review

This is a major bump, so I diffed the upstream sources that this package actually depends on:

- **`FileTransfer/Server/Main.hs` is byte-identical** across the bump — the generated `file-server.ini` does not change.
- **`Messaging/Server/CLI.hs` is byte-identical**; `init` CLI flags (`-y -l --password`, and xftp's `-p/-q`) are unchanged, so `initServers` still works as written.
- **`Messaging/Server/Main/Init.hs`** (generates `smp-server.ini`) gains exactly one block: a new opt-in `[NAMES]` section for the new SNRC name resolver, with `enable: off` plus commented-out keys.
- **`Messaging/Server/Main.hs`** drops the `[TRANSPORT] accept_service_credentials` option (now hardcoded `True`). The package never modelled or wrote that key, so there is nothing to clean up.

**No migration is needed.** The package's INI models don't reference any changed key, and upstream defaults `[NAMES] enable` to `False` when the section is absent — which is the state the package's file model produces, since `FileHelper.merge` validates through the zod shape and the custom INI writer rebuilds the file from the model. Behaviour is identical to v6.5.2.

## Release-notes highlights

Drawn from the upstream commit list for the 6.5.3 → 7.0.0 range (upstream's `CHANGELOG.md` stops at 6.5.1, so the release body is the real source):

- two SMP server memory leaks fixed (subscriptions #1820, service subscriptions #1827)
- SMP proxy reconnection to a relay after restart (#1806) — relevant to this package's Tor-proxy path
- hardening: decompressed-size limit (#1815), sntrup length validation (#1811), BBS proof validation (#1810), duplicate short-link updates rejected (#1813)
- bracketed IPv6 server addresses parsed (#1807)

## Other changes

- `tor-startos` refreshed `e3e2b53` → `aa867cf` (current `#next` tip).
- **No SDK bump** — `@start9labs/start-sdk` is already pinned at `2.0.9`, which is npm `latest`.
- Lockfile converged to a fixed point (3 installs, byte-stable); one `start-sdk` copy on disk and no nested copy in the lock, as the existing `overrides` block intends.
- `README.md` / `instructions.md` need no edit for this bump: neither carries version strings, and the bump changes no user-visible behaviour.

## Proposals (not implemented — for review)

1. **Expose the new `[NAMES]` section?** v7.0.0 adds opt-in public-namespace resolution, which needs an external SNRC resolver endpoint (`resolver_endpoint`, plus optional auth/timeout keys). It's off by default and requires infrastructure this package doesn't ship, so I left it alone rather than guessing at a UI for it.

2. **`instructions.md:39` looks inaccurate, and v7 makes it more visible.** It says *"anything else you set by editing the INI files directly in the config volumes will be preserved."* In practice `FileHelper.merge` runs the parsed file through `shape.parse` (a `z.object`, which strips unknown keys) and the custom writer rebuilds the file from that model, so hand-added keys/sections are dropped on the next merge. This predates the bump, but `[NAMES]` is exactly the kind of section a user would now try to hand-enable. Worth either correcting the prose or modelling the extra keys — happy to do whichever in a follow-up.

## Test plan

- [x] `npm run check` (tsc) green at `7.0.0:0`
- [x] Prettier clean on the touched files
- [x] Both `v7.0.0` images resolve on Docker Hub for both arches
- [x] `7.0.0:0` is free — registry's newest published version is `6.5.2:5`
- [ ] `make` / s9pk build + install-and-run smoke test (PR review)
