### PR TITLE
chore: bump SimpleX to 7.0.1; 7.0.0:0 → 7.0.1:0

### DIFF
--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -25,13 +25,13 @@ export const manifest = setupManifest({
   images: {
     smp: {
       source: {
-        dockerTag: 'simplexchat/smp-server:v7.0.0',
+        dockerTag: 'simplexchat/smp-server:v7.0.1',
       },
       arch: ['x86_64', 'aarch64'],
     },
     xftp: {
       source: {
-        dockerTag: 'simplexchat/xftp-server:v7.0.0',
+        dockerTag: 'simplexchat/xftp-server:v7.0.1',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,48 +1,33 @@
 import { VersionInfo } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '7.0.0:0',
+  version: '7.0.1:0',
   releaseNotes: {
-    en_US: `Updated SimpleX to 7.0.0.
+    en_US: `Updated SimpleX to 7.0.1.
 
-- Fixes two memory leaks in the SMP server that grew as clients subscribed and unsubscribed.
-- The SMP proxy reconnects reliably to a relay after that relay restarts.
-- Hardening across cryptography and message parsing, including a limit on decompressed message size.
-- Accepts IPv6 server addresses written in bracketed form.
+A small maintenance release with a single fix for the SMP server: when relaying messages for private routing, the server no longer creates an internal message queue that was never drained, which could leak memory and stall message processing. The XFTP file server is unchanged.
 
-Full upstream release notes: https://github.com/simplex-chat/simplexmq/releases/tag/v7.0.0`,
-    es_ES: `Actualiza SimpleX a la versión 7.0.0.
+Full upstream release notes: https://github.com/simplex-chat/simplexmq/releases/tag/v7.0.1`,
+    es_ES: `Actualiza SimpleX a la versión 7.0.1.
 
-- Corrige dos fugas de memoria en el servidor SMP que crecían a medida que los clientes se suscribían y cancelaban su suscripción.
-- El proxy SMP se reconecta de forma fiable a un repetidor después de que este se reinicie.
-- Refuerzo de la criptografía y del análisis de mensajes, incluido un límite en el tamaño de los mensajes descomprimidos.
-- Acepta direcciones de servidor IPv6 escritas entre corchetes.
+Una pequeña versión de mantenimiento con una única corrección para el servidor SMP: al retransmitir mensajes para el enrutamiento privado, el servidor ya no crea una cola de mensajes interna que nunca se vaciaba, lo que podía provocar fugas de memoria y detener el procesamiento de mensajes. El servidor de archivos XFTP no ha cambiado.
 
-Notas completas de la versión original: https://github.com/simplex-chat/simplexmq/releases/tag/v7.0.0`,
-    de_DE: `Aktualisiert SimpleX auf 7.0.0.
+Notas completas de la versión original: https://github.com/simplex-chat/simplexmq/releases/tag/v7.0.1`,
+    de_DE: `Aktualisiert SimpleX auf 7.0.1.
 
-- Behebt zwei Speicherlecks im SMP-Server, die mit dem An- und Abmelden von Clients anwuchsen.
-- Der SMP-Proxy verbindet sich nach einem Neustart des Relays zuverlässig wieder mit diesem.
-- Härtung von Kryptografie und Nachrichtenverarbeitung, einschließlich einer Begrenzung der entpackten Nachrichtengröße.
-- Akzeptiert IPv6-Serveradressen in Klammerschreibweise.
+Eine kleine Wartungsversion mit einer einzigen Korrektur für den SMP-Server: Beim Weiterleiten von Nachrichten für das Private Routing erstellt der Server keine interne Nachrichtenwarteschlange mehr, die nie geleert wurde und zu Speicherlecks sowie zum Stocken der Nachrichtenverarbeitung führen konnte. Der XFTP-Dateiserver ist unverändert.
 
-Vollständige Versionshinweise des Upstream-Projekts: https://github.com/simplex-chat/simplexmq/releases/tag/v7.0.0`,
-    pl_PL: `Aktualizuje SimpleX do wersji 7.0.0.
+Vollständige Versionshinweise des Upstream-Projekts: https://github.com/simplex-chat/simplexmq/releases/tag/v7.0.1`,
+    pl_PL: `Aktualizuje SimpleX do wersji 7.0.1.
 
-- Naprawia dwa wycieki pamięci w serwerze SMP, które narastały wraz z subskrybowaniem i anulowaniem subskrypcji przez klientów.
-- Proxy SMP niezawodnie łączy się ponownie z przekaźnikiem po jego ponownym uruchomieniu.
-- Wzmocnienia w kryptografii i przetwarzaniu wiadomości, w tym limit rozmiaru zdekompresowanych wiadomości.
-- Obsługuje adresy serwerów IPv6 zapisane w nawiasach kwadratowych.
+Niewielkie wydanie konserwacyjne z jedną poprawką serwera SMP: podczas przekazywania wiadomości w ramach prywatnego routingu serwer nie tworzy już wewnętrznej kolejki wiadomości, która nigdy nie była opróżniana, co mogło powodować wycieki pamięci i wstrzymanie przetwarzania wiadomości. Serwer plików XFTP pozostaje bez zmian.
 
-Pełne informacje o wydaniu od twórców: https://github.com/simplex-chat/simplexmq/releases/tag/v7.0.0`,
-    fr_FR: `Met à jour SimpleX vers la version 7.0.0.
+Pełne informacje o wydaniu od twórców: https://github.com/simplex-chat/simplexmq/releases/tag/v7.0.1`,
+    fr_FR: `Met à jour SimpleX vers la version 7.0.1.
 
-- Corrige deux fuites de mémoire du serveur SMP qui augmentaient au fil des abonnements et désabonnements des clients.
-- Le proxy SMP se reconnecte de manière fiable à un relais après le redémarrage de celui-ci.
-- Renforcement de la cryptographie et de l'analyse des messages, dont une limite sur la taille des messages décompressés.
-- Accepte les adresses de serveur IPv6 écrites entre crochets.
+Une petite version de maintenance avec un seul correctif pour le serveur SMP : lors du relais de messages pour le routage privé, le serveur ne crée plus de file d'attente de messages interne qui n'était jamais vidée, ce qui pouvait entraîner des fuites de mémoire et bloquer le traitement des messages. Le serveur de fichiers XFTP est inchangé.
 
-Notes de version complètes du projet amont : https://github.com/simplex-chat/simplexmq/releases/tag/v7.0.0`,
+Notes de version complètes du projet amont : https://github.com/simplex-chat/simplexmq/releases/tag/v7.0.1`,
   },
   migrations: {},
 })


### PR DESCRIPTION
## Summary

Bumps SimpleX to **7.0.1** — `7.0.0:0` → `7.0.1:0`.

Both images move in lockstep per `UPDATING.md`:

| Image | Old | New |
| --- | --- | --- |
| `simplexchat/smp-server` | `v7.0.0` | `v7.0.1` |
| `simplexchat/xftp-server` | `v7.0.0` | `v7.0.1` |

## Upstream check

`v7.0.1` is the newest plain `vX.Y.Z` tag on `simplex-chat/simplexmq`. As `UPDATING.md` warns, it is flagged a GitHub *pre-release* — the tag-list filter is the authority here, not `gh release view`.

Both Docker images are published for `amd64` and `arm64` (2026-07-31):

- `simplexchat/smp-server:v7.0.1` → `sha256:7d825822839a…`
- `simplexchat/xftp-server:v7.0.1` → `sha256:69a7f95746bb…`

## What's in the release

`v7.0.0...v7.0.1` is three commits. Only one is reachable from what this package ships:

- **SMP server — no messaging queues in the SMP proxy** ([#1839](https://github.com/simplex-chat/simplexmq/pull/1839)). The server's SMP client agent allocated a bounded message queue even when acting as a proxy, where only subscribing agents ever drain it. Late responses accumulated (memory leak) and processing deadlocked once the queue filled. `smpAgentCfg.msgQSize` is now `Nothing` for the server. This is live for our users — the SMP server relays for private routing, and the `tor-settings` action wires a SOCKS proxy into `[PROXY] socks_proxy` for exactly that path.
- Notification server push-worker sharding ([#1840](https://github.com/simplex-chat/simplexmq/pull/1840)) — `ntf-server` is not shipped by this package.
- Version bump commit.

`xftp-server` has no code changes in this release; its image is rebuilt at the new version to keep the pins in lockstep.

Upstream's `CHANGELOG.md` has not been updated past 6.5.1, so the release notes link to the GitHub release page.

## Dependencies

No changes rode along:

- `@start9labs/start-sdk` is already at **2.0.9**, the latest on npm.
- `tor-startos#next` is already pinned at its tip (`aa867cf`). Git deps were dropped from `package-lock.json` and re-resolved anyway to confirm — the lock came back **byte-identical** and is stable across repeated installs, with zero nested `@start9labs/start-sdk` copies.

## Test plan

- `npm run check` (tsc) — green.
- `prettier --check` on both touched files — clean.
- Both `v7.0.1` image tags verified to resolve on Docker Hub for `x86_64` and `aarch64` before pinning.
- No migration needed — a patch-level upstream bump with no on-disk state change, so `current.ts` is edited in place at `7.0.1:0` and `migrations` stays empty.
- Release notes updated in all five locales, describing only what `7.0.1` adds on top of the `7.0.0:0` release already on `master`.

Not run per monitor-cycle policy: `make` / Docker builds / s9pk pack.
