### PR TITLE
fix: initialize the servers before publishing their addresses (7.0.1:1)

### DIFF
--- a/startos/init/index.ts
+++ b/startos/init/index.ts
@@ -10,9 +10,9 @@ import { watchTorProxy } from './watchTorProxy'
 export const init = sdk.setupInit(
   restoreInit,
   versionGraph,
+  initServers,
   setInterfaces,
   actions,
-  initServers,
   watchTorProxy,
   setDependencies,
 )

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,29 +1,39 @@
 import { VersionInfo } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '7.0.1:0',
+  version: '7.0.1:1',
   releaseNotes: {
-    en_US: `Updated SimpleX to 7.0.1.
+    en_US: `Fixes the SMP and XFTP relay addresses being published before the server has finished initializing, which briefly advertised an address no client could use.
+
+Updated SimpleX to 7.0.1.
 
 A small maintenance release with a single fix for the SMP server: when relaying messages for private routing, the server no longer creates an internal message queue that was never drained, which could leak memory and stall message processing. The XFTP file server is unchanged.
 
 Full upstream release notes: https://github.com/simplex-chat/simplexmq/releases/tag/v7.0.1`,
-    es_ES: `Actualiza SimpleX a la versión 7.0.1.
+    es_ES: `Corrige la publicación de las direcciones de los relés SMP y XFTP antes de que el servidor termine de inicializarse, lo que anunciaba brevemente una dirección que ningún cliente podía usar.
+
+Actualiza SimpleX a la versión 7.0.1.
 
 Una pequeña versión de mantenimiento con una única corrección para el servidor SMP: al retransmitir mensajes para el enrutamiento privado, el servidor ya no crea una cola de mensajes interna que nunca se vaciaba, lo que podía provocar fugas de memoria y detener el procesamiento de mensajes. El servidor de archivos XFTP no ha cambiado.
 
 Notas completas de la versión original: https://github.com/simplex-chat/simplexmq/releases/tag/v7.0.1`,
-    de_DE: `Aktualisiert SimpleX auf 7.0.1.
+    de_DE: `Behebt, dass die SMP- und XFTP-Relay-Adressen veröffentlicht wurden, bevor der Server seine Initialisierung abgeschlossen hatte, wodurch kurzzeitig eine für Clients unbrauchbare Adresse angezeigt wurde.
+
+Aktualisiert SimpleX auf 7.0.1.
 
 Eine kleine Wartungsversion mit einer einzigen Korrektur für den SMP-Server: Beim Weiterleiten von Nachrichten für das Private Routing erstellt der Server keine interne Nachrichtenwarteschlange mehr, die nie geleert wurde und zu Speicherlecks sowie zum Stocken der Nachrichtenverarbeitung führen konnte. Der XFTP-Dateiserver ist unverändert.
 
 Vollständige Versionshinweise des Upstream-Projekts: https://github.com/simplex-chat/simplexmq/releases/tag/v7.0.1`,
-    pl_PL: `Aktualizuje SimpleX do wersji 7.0.1.
+    pl_PL: `Naprawia publikowanie adresów przekaźników SMP i XFTP, zanim serwer zakończy inicjalizację, przez co przez chwilę ogłaszany był adres nieużyteczny dla klientów.
+
+Aktualizuje SimpleX do wersji 7.0.1.
 
 Niewielkie wydanie konserwacyjne z jedną poprawką serwera SMP: podczas przekazywania wiadomości w ramach prywatnego routingu serwer nie tworzy już wewnętrznej kolejki wiadomości, która nigdy nie była opróżniana, co mogło powodować wycieki pamięci i wstrzymanie przetwarzania wiadomości. Serwer plików XFTP pozostaje bez zmian.
 
 Pełne informacje o wydaniu od twórców: https://github.com/simplex-chat/simplexmq/releases/tag/v7.0.1`,
-    fr_FR: `Met à jour SimpleX vers la version 7.0.1.
+    fr_FR: `Corrige la publication des adresses des relais SMP et XFTP avant la fin de l'initialisation du serveur, qui annonçait brièvement une adresse inutilisable par les clients.
+
+Met à jour SimpleX vers la version 7.0.1.
 
 Une petite version de maintenance avec un seul correctif pour le serveur SMP : lors du relais de messages pour le routage privé, le serveur ne crée plus de file d'attente de messages interne qui n'était jamais vidée, ce qui pouvait entraîner des fuites de mémoire et bloquer le traitement des messages. Le serveur de fichiers XFTP est inchangé.
 


### PR DESCRIPTION
On install, the SMP and XFTP addresses were published as:

```
smp://undefined:null@relay.example:5223
```

Well-formed enough for a client to accept and store, and impossible to authenticate against.

## Cause: init order, not a race

```ts
export const init = sdk.setupInit(
  restoreInit,
  versionGraph,
  setInterfaces,   // 3rd — reads the fingerprint and the password
  actions,
  initServers,     // 5th — runs `smp-server init`, which writes them
  watchTorProxy,
  setDependencies,
)
```

`setupInit` runs handlers sequentially, so on a fresh install `setInterfaces` executed before `smp-server init` had ever run. `smp-configs` is empty at that point — no `fingerprint` file, no `smp-server.ini` to read `AUTH.create_password` from — and both empty reads were interpolated straight into `username`.

The pass does re-run on its own, since both reads are `.const()` and `setupInit` gives each handler a `constRetry`. But the window it corrects is two subcontainer spawns doing keypair generation wide, and it recurs on every reinstall — with a fresh CA on the other side.

## Fix

**`initServers` moves above `setInterfaces`.** It's a seed step: it reads no host or interface state, only volumes and file models (`smpMounts`/`xftpMounts` are plain volume mounts), while `setInterfaces` is the thing that consumes what it writes. The dependency only ever ran one way. This matches how `lnd` and `cln` — the other two packages whose `setInterfaces` reads generated files — order their own seed steps ahead of it.

That's the whole change. The reads are left unguarded, because after the reorder nothing can reach them empty: `execFail` throws if `smp-server init` fails, the non-install path already throws when the ini carries no `create_password`, and `setupInit` awaits each handler without catching — so either failure aborts init rather than arriving at `setInterfaces` with nothing to read.

(`lnd` and `cln` do guard their equivalent reads, but for a condition this package doesn't have: their credentials are deleted and re-minted at runtime by rune revocation and macaroon rotation, so both pass a custom `eq` to ignore the gap. Nothing here ever removes the fingerprint.)

Bumped to `7.0.1:1`; wrapper-only, no migration.

## How it surfaced

`simplex-websocket-bridge-startos` resolves this interface as its Local relay and picked up the `undefined:null` form while following a reinstalled server to its new address. It landed a fingerprint-shape guard on its side ([Start9-Community/simplex-websocket-bridge-startos#14](https://github.com/Start9-Community/simplex-websocket-bridge-startos/pull/14)) — worth keeping regardless, since a consumer shouldn't trust a relay URI's shape — but the malformed value originated here.

Related: [Start9Labs/start-technologies#3861](https://github.com/Start9Labs/start-technologies/pull/3861) fixes the SDK-side reason the bridge stopped noticing address changes at all.
